### PR TITLE
Updated adapter to Slim 3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "slim/slim": "^3.0",
+        "slim/slim": "^3.1",
         "phpfastcgi/fastcgi-daemon": "^0.7"
     },
     "require-dev": {

--- a/test/AppWrapperTest.php
+++ b/test/AppWrapperTest.php
@@ -5,7 +5,6 @@ namespace PHPFastCGI\Test\Slimmer;
 use PHPFastCGI\Adapter\Slim\AppWrapper;
 use PHPFastCGI\FastCGIDaemon\Http\Request;
 use Slim\App;
-use Slim\Exception\Exception as SlimException;
 use Zend\Diactoros\Response\HtmlResponse;
 
 /**
@@ -31,7 +30,7 @@ class AppWrapperTest extends \PHPUnit_Framework_TestCase
         $kernel = new AppWrapper($app);
 
         // Create a request to test the route set up for the app
-        $stream  = fopen('php://temp', 'r');
+        $stream = fopen('php://temp', 'r');
         $request = new Request(['REQUEST_URI' => '/hello/Andrew'], $stream);
 
         // Get the response from the kernel that is wrapping the app
@@ -39,104 +38,6 @@ class AppWrapperTest extends \PHPUnit_Framework_TestCase
 
         // Check that the app has been wrapper properly by comparing to expected response
         $this->assertSame('Hello, Andrew', (string) $response->getBody());
-
-        fclose($stream);
-    }
-
-    /**
-     * Tests that slim exception is handled correctly
-     */
-    public function testSlimException()
-    {
-        // Create the Slim app
-        $app = new App();
-
-        // Create a Slim Exception to throw
-        $expectedResponse = new HtmlResponse('<h1>Error</h1>');
-        $slimException = new SlimException($expectedResponse);
-
-        // Add a simple route to the app that throws the exception
-        $app->get('/hello/{name}', function ($request, $response, $args) use ($slimException) {
-            throw $slimException;
-        });
-
-        // Create a kernel for the FastCGI daemon using the Slim app
-        $kernel = new AppWrapper($app);
-
-        // Create a request to test the route set up for the app
-        $stream  = fopen('php://temp', 'r');
-        $request = new Request(['REQUEST_URI' => '/hello/Andrew'], $stream);
-
-        // Get the response from the kernel that is wrapping the app
-        $response = $kernel->handleRequest($request);
-
-        // Check that the app has been wrapper properly by comparing to expected response
-        $this->assertEquals((string) $expectedResponse->getBody(), (string) $response->getBody());
-
-        fclose($stream);
-    }
-
-    /**
-     * Tests that an exception is handled correctly
-     */
-    public function testException()
-    {
-        // Create the Slim app
-        $app = new App();
-
-        // Add a simple route to the app that throws a general exception
-        $app->get('/hello/{name}', function ($request, $response, $args) {
-            throw new \Exception;
-        });
-
-        // Create a kernel for the FastCGI daemon using the Slim app
-        $kernel = new AppWrapper($app);
-
-        // Create a request to test the route set up for the app
-        $stream  = fopen('php://temp', 'r');
-        $request = new Request(['REQUEST_URI' => '/hello/Andrew'], $stream);
-
-        // Get the response from the kernel that is wrapping the app
-        $response = $kernel->handleRequest($request);
-
-        // Check that the app has returned a valid response
-        $this->assertInstanceOf('Psr\Http\Message\ResponseInterface', $response);
-
-        fclose($stream);
-    }
-
-    /**
-     * Tests that content headers are stripped on 204/304 messages
-     */
-    public function testStrippedContentHeaders()
-    {
-        // Create the Slim app
-        $app = new App();
-
-        // Add a simple route to the app that throws a general exception
-        $app->get('/hello/{name}', function ($request, $response, $args) {
-            $response = new HtmlResponse('Hello');
-
-            return $response
-                ->withStatus(204)
-                ->withAddedHeader('Content-Type', 'text/plain')
-                ->withAddedHeader('Content-Length', (string) 10);
-        });
-
-        // Create a kernel for the FastCGI daemon using the Slim app
-        $kernel = new AppWrapper($app);
-
-        // Create a request to test the route set up for the app
-        $stream  = fopen('php://temp', 'r');
-        $request = new Request(['REQUEST_URI' => '/hello/Andrew'], $stream);
-
-        // Get the response from the kernel that is wrapping the app
-        $response = $kernel->handleRequest($request);
-
-        // Check that the app has returned a valid response
-        $this->assertEquals('Hello', (string) $response->getBody());
-        $this->assertFalse($response->hasHeader('Content-Type'));
-        $this->assertFalse($response->hasHeader('Content-Length'));
 
         fclose($stream);
     }


### PR DESCRIPTION
Slim 3.1 introduces the [App::process() method](https://github.com/slimphp/Slim/pull/1688) which can be used to make this adapter a lot simpler.
